### PR TITLE
Fix url of deno/std 🔧

### DIFF
--- a/version.ts
+++ b/version.ts
@@ -1,7 +1,7 @@
 // We handle the methods to look for the latest versions
 import { dependencyType } from "./types/dependencyType.ts";
 import { soxa } from 'https://deno.land/x/soxa/mod.ts';
-import { VERSION } from 'https://raw.githubusercontent.com/denoland/deno/master/std/version.ts';
+import { VERSION } from 'https://raw.githubusercontent.com/denoland/deno_std/main/version.ts';
 
 export async function addLatestVersions(dependencies: dependencyType[]): Promise<dependencyType[]> {
   let result;


### PR DESCRIPTION
Deno std library has been moved out from denoland/deno to denoland/deno_std so script seems broken currently:
```
error: Import 'https://raw.githubusercontent.com/denoland/deno/master/std/version.ts' failed: 404 Not Found
    at https://deno.land/x/deno_check_updates@v0.3/version.ts:4:0
```